### PR TITLE
Require JSON

### DIFF
--- a/lib/workos/audit_trail.rb
+++ b/lib/workos/audit_trail.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 # typed: true
 
+require 'json'
 require 'net/http'
 require 'uri'
 

--- a/lib/workos/client.rb
+++ b/lib/workos/client.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 # typed: true
 
+require 'json'
+
 module WorkOS
   # A Net::HTTP based API client for interacting with the WorkOS API
   module Client

--- a/lib/workos/directory_sync.rb
+++ b/lib/workos/directory_sync.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 # typed: true
 
+require 'json'
 require 'net/http'
 
 module WorkOS

--- a/lib/workos/passwordless.rb
+++ b/lib/workos/passwordless.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 # typed: true
 
+require 'json'
 require 'net/http'
 
 module WorkOS

--- a/lib/workos/portal.rb
+++ b/lib/workos/portal.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 # typed: true
 
+require 'json'
 require 'net/http'
 
 module WorkOS

--- a/lib/workos/sso.rb
+++ b/lib/workos/sso.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 # typed: true
 
+require 'json'
 require 'net/http'
 require 'uri'
 


### PR DESCRIPTION
While writing an example program for #1, I noticed an error
when not requiring JSON from the standard library:

```
gems/workos-0.9.1/lib/workos/client.rb:65:in `post_request':
undefined method `to_json' for #<Hash:0x00007fa22e11b4f8> (NoMethodError)
```

Example:

```ruby
require 'date'
require 'workos'

WorkOS.key = ENV.fetch('WORKOS_API_KEY')

event = {
  action_type: 'r',
  action: 'user.login_succeeded',
  actor_id: 'user_01DEQWZNQT8Y47HDPSJKQS1J3F',
  actor_name: 'WorkOS Ruby Gem Test',
  group: 'foo-corp.com',
  latitude: '40.676300',
  longitude: '-73.949200',
  location: '65.215.8.114',
  occurred_at: DateTime.now.iso8601,
  target_id: 'user_01DEQWZNQT8Y47HDPSJKQS1J3F',
  target_name: 'WorkOS Ruby Gem Test'
}

WorkOS::AuditTrail.create_event(event: event)
```

I believe the code worked in my Rails app as a side effect of other
dependencies and in the workos-ruby test suite due to `simplecov` gem
depending on `json` gem as a development dependency.

Files with `JSON` or `to_json` need to `require 'json'` for example
programs like the snippets in API reference to work standalone:
https://workos.com/docs/reference/audit-trail/event/publish

Reduced further:

```ruby
{}.to_json # undefined method `to_json' for {}:Hash (NoMethodError)
JSON.parse("{}") # uninitialized constant JSON (NameError)
```